### PR TITLE
Add repository link constant

### DIFF
--- a/app/src/main/java/com/example/tvapp/ContentRepository.kt
+++ b/app/src/main/java/com/example/tvapp/ContentRepository.kt
@@ -82,6 +82,8 @@ class ContentRepository(private val context: Context) {
     }
 
     companion object {
+        // Public GitHub repository containing the source code
+        const val REPO_URL = "https://github.com/radcactusmedia/beacon.git"
         const val MESSAGE_URL = "https://raw.githubusercontent.com/example/repo/main/message.json"
         const val PLAYLIST_URL = "https://raw.githubusercontent.com/example/repo/main/playlist.json"
     }


### PR DESCRIPTION
## Summary
- add constant `REPO_URL` pointing to the public GitHub repository

## Testing
- `gradle build` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68425de2add48328b70602b310bd7684