### PR TITLE
Show splash when no media

### DIFF
--- a/app/src/main/java/com/example/tvapp/SlideshowPlayer.kt
+++ b/app/src/main/java/com/example/tvapp/SlideshowPlayer.kt
@@ -35,8 +35,8 @@ fun SlideshowPlayer(viewModel: TvViewModel) {
         index = 0
     }
 
-    LaunchedEffect(showSplash) {
-        if (showSplash) {
+    LaunchedEffect(showSplash, playlist) {
+        if (showSplash && playlist.isNotEmpty()) {
             delay(10_000)
             showSplash = false
             showLoading = true
@@ -73,7 +73,7 @@ fun SlideshowPlayer(viewModel: TvViewModel) {
     }
 
     when {
-        showSplash && splashFile != null -> {
+        (showSplash || playlist.isEmpty()) && splashFile != null -> {
             MediaItemView(file = splashFile, player = player)
         }
         showLoading -> {


### PR DESCRIPTION
## Summary
- keep splash visible until media is present

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425f0857f08328bc8397592b7ccbe1