### PR TITLE
Add Gradle memory config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Summary
- add `gradle.properties` to increase Gradle's heap size

## Testing
- `gradle test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d90e09498832880566a9802976eca