### PR TITLE
Fix AndroidX issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+
+android.useAndroidX=true


### PR DESCRIPTION
## Summary
- enable AndroidX support in gradle.properties to prevent build failure

## Testing
- `gradle build` *(fails: Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_684d931c41608328a9c71f1ab6bbd49b